### PR TITLE
Add SkeletonButton to Boards

### DIFF
--- a/src/components/Boards.js
+++ b/src/components/Boards.js
@@ -10,6 +10,7 @@ import BoardCard from './BoardCard'
 import Grid from './Grid'
 import Button from './Button'
 import Flex from './Flex'
+import SkeletonButton from './SkeletonButton'
 
 export const BOARDS_QUERY = gql`
   query BoardsQuery {
@@ -41,6 +42,12 @@ function Boards() {
                   {data.boards.map(board => (
                     <BoardCard key={board.id} board={board} />
                   ))}
+
+                  <SkeletonButton
+                    onClick={() => modal.openModal(CreateBoardModal)}
+                  >
+                    New board
+                  </SkeletonButton>
                 </Grid>
               )
             }}

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -28,10 +28,12 @@ const DELETE_COLUMN_MUTATION = gql`
   }
 `
 
+export const COLUMN_WIDTH = 360
+
 const ColumnContainer = glamorous.div({
   display: 'flex',
   flexDirection: 'column',
-  width: 360,
+  width: COLUMN_WIDTH,
   marginRight: spacing[3],
   padding: spacing[3],
   backgroundColor: colors.white,

--- a/src/components/Columns.js
+++ b/src/components/Columns.js
@@ -6,7 +6,7 @@ import glamorous from 'glamorous'
 
 import { BOARD_QUERY } from './BoardPage'
 import { spacing } from '../theme'
-import Column from './Column'
+import Column, { COLUMN_WIDTH } from './Column'
 import SkeletonButton from './SkeletonButton'
 
 const CREATE_COLUMN_MUTATION = gql`
@@ -64,6 +64,7 @@ function Columns({ boardId, columns }) {
               <Column key={column.id} boardId={boardId} column={column} />
             ))}
             <SkeletonButton
+              width={COLUMN_WIDTH}
               onClick={() =>
                 createColumn({
                   variables: {

--- a/src/components/SkeletonButton.js
+++ b/src/components/SkeletonButton.js
@@ -1,3 +1,4 @@
+import { number, oneOfType, string } from 'prop-types'
 import glamorous from 'glamorous'
 
 import {
@@ -8,12 +9,13 @@ import {
   colors,
   radii,
   transition,
+  breakpoints,
 } from '../theme'
 import { joinSpacing, toAlpha } from '../utils/style'
 
-const SkeletonButton = glamorous.button({
-  width: 360,
-  padding: joinSpacing(spacing[6], 0),
+const SkeletonButton = glamorous.button(props => ({
+  width: props.width,
+  padding: joinSpacing(spacing[4], 0),
   fontFamily: 'inherit',
   fontWeight: fontWeights.bold,
   fontSize: fontSizes[2],
@@ -29,6 +31,18 @@ const SkeletonButton = glamorous.button({
   ':hover,:focus': {
     backgroundColor: toAlpha(colors.gray[1]),
   },
-})
+
+  [breakpoints.sm]: {
+    padding: joinSpacing(spacing[6], 0),
+  },
+}))
+
+SkeletonButton.propTypes = {
+  width: oneOfType([number, string]),
+}
+
+SkeletonButton.defaultProps = {
+  width: 'inherit',
+}
 
 export default SkeletonButton

--- a/src/components/SkeletonButton.js
+++ b/src/components/SkeletonButton.js
@@ -42,7 +42,7 @@ SkeletonButton.propTypes = {
 }
 
 SkeletonButton.defaultProps = {
-  width: 'inherit',
+  width: '100%',
 }
 
 export default SkeletonButton

--- a/src/components/SkeletonButton.js
+++ b/src/components/SkeletonButton.js
@@ -1,4 +1,4 @@
-import { number, oneOfType, string } from 'prop-types'
+import { number, oneOfType, string, func } from 'prop-types'
 import glamorous from 'glamorous'
 
 import {
@@ -39,10 +39,12 @@ const SkeletonButton = glamorous.button(props => ({
 
 SkeletonButton.propTypes = {
   width: oneOfType([number, string]),
+  onClick: func,
 }
 
 SkeletonButton.defaultProps = {
   width: '100%',
+  onClick: () => {},
 }
 
 export default SkeletonButton

--- a/src/components/__tests__/Button.tests.js
+++ b/src/components/__tests__/Button.tests.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { renderIntoDocument, render, fireEvent } from 'react-testing-library'
+
 import Button from '../Button'
 
 it('renders without crashing', () => {
@@ -44,6 +45,5 @@ it('calls onClick when button is clicked', () => {
       cancelable: true,
     }),
   )
-
   expect(handleClick).toHaveBeenCalledTimes(1)
 })

--- a/src/components/__tests__/SkeletonButton.test.js
+++ b/src/components/__tests__/SkeletonButton.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { renderIntoDocument, render, fireEvent } from 'react-testing-library'
+
 import SkeletonButton from '../SkeletonButton'
 
 it('renders without crashing', () => {
@@ -30,6 +31,5 @@ it('calls onClick when button is clicked', () => {
       cancelable: true,
     }),
   )
-
   expect(handleClick).toHaveBeenCalledTimes(1)
 })

--- a/src/components/__tests__/SkeletonButton.test.js
+++ b/src/components/__tests__/SkeletonButton.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { renderIntoDocument, render, fireEvent } from 'react-testing-library'
+import SkeletonButton from '../SkeletonButton'
+
+it('renders without crashing', () => {
+  const { container } = render(
+    <SkeletonButton>Test SkeletonButton</SkeletonButton>,
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})
+
+it('renders with custom width', () => {
+  const { container } = render(
+    <SkeletonButton width={360}>Custom Width SkeletonButton</SkeletonButton>,
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})
+
+it('calls onClick when button is clicked', () => {
+  const handleClick = jest.fn()
+  const { getByText } = renderIntoDocument(
+    <SkeletonButton onClick={handleClick}>
+      Clickable SkeletonButton
+    </SkeletonButton>,
+  )
+  fireEvent(
+    getByText('Clickable SkeletonButton'),
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+
+  expect(handleClick).toHaveBeenCalledTimes(1)
+})

--- a/src/components/__tests__/SkeletonButton.test.js
+++ b/src/components/__tests__/SkeletonButton.test.js
@@ -10,9 +10,16 @@ it('renders without crashing', () => {
   expect(container.firstChild).toMatchSnapshot()
 })
 
-it('renders with custom width', () => {
+it('renders with custom number width', () => {
   const { container } = render(
     <SkeletonButton width={360}>Custom Width SkeletonButton</SkeletonButton>,
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})
+
+it('renders with custom percentage width', () => {
+  const { container } = render(
+    <SkeletonButton width={'100%'}>Custom Width SkeletonButton</SkeletonButton>,
   )
   expect(container.firstChild).toMatchSnapshot()
 })

--- a/src/components/__tests__/__snapshots__/SkeletonButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/SkeletonButton.test.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders with custom width 1`] = `
+.css-0,
+[data-css-0] {
+  width: 360px;
+  padding: 24px 0;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: rgba(0, 17, 34, 0.47);
+  background-color: transparent;
+  border: 2px dashed rgba(0, 31, 62, 0.19);
+  border-radius: 6px;
+  cursor: pointer;
+  outline: 0;
+  transition: background-color 150ms ease-in-out;
+  -webkit-transition: background-color 150ms ease-in-out;
+  -moz-transition: background-color 150ms ease-in-out;
+}
+
+.css-0:hover,
+[data-css-0]:hover,
+.css-0:focus,
+[data-css-0]:focus {
+  background-color: rgba(0, 36, 73, 0.05);
+}
+
+@media screen and (min-width: 32em) {
+  .css-0,
+  [data-css-0] {
+    padding: 64px 0;
+  }
+}
+
+<button
+  class="css-0"
+>
+  Custom Width SkeletonButton
+</button>
+`;
+
+exports[`renders without crashing 1`] = `
+.css-0,
+[data-css-0] {
+  width: 100%;
+  padding: 24px 0;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: rgba(0, 17, 34, 0.47);
+  background-color: transparent;
+  border: 2px dashed rgba(0, 31, 62, 0.19);
+  border-radius: 6px;
+  cursor: pointer;
+  outline: 0;
+  transition: background-color 150ms ease-in-out;
+  -webkit-transition: background-color 150ms ease-in-out;
+  -moz-transition: background-color 150ms ease-in-out;
+}
+
+.css-0:hover,
+[data-css-0]:hover,
+.css-0:focus,
+[data-css-0]:focus {
+  background-color: rgba(0, 36, 73, 0.05);
+}
+
+@media screen and (min-width: 32em) {
+  .css-0,
+  [data-css-0] {
+    padding: 64px 0;
+  }
+}
+
+<button
+  class="css-0"
+>
+  Test SkeletonButton
+</button>
+`;

--- a/src/components/__tests__/__snapshots__/SkeletonButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/SkeletonButton.test.js.snap
@@ -1,9 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders with custom width 1`] = `
+exports[`renders with custom number width 1`] = `
 .css-0,
 [data-css-0] {
   width: 360px;
+  padding: 24px 0;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: rgba(0, 17, 34, 0.47);
+  background-color: transparent;
+  border: 2px dashed rgba(0, 31, 62, 0.19);
+  border-radius: 6px;
+  cursor: pointer;
+  outline: 0;
+  transition: background-color 150ms ease-in-out;
+  -webkit-transition: background-color 150ms ease-in-out;
+  -moz-transition: background-color 150ms ease-in-out;
+}
+
+.css-0:hover,
+[data-css-0]:hover,
+.css-0:focus,
+[data-css-0]:focus {
+  background-color: rgba(0, 36, 73, 0.05);
+}
+
+@media screen and (min-width: 32em) {
+  .css-0,
+  [data-css-0] {
+    padding: 64px 0;
+  }
+}
+
+<button
+  class="css-0"
+>
+  Custom Width SkeletonButton
+</button>
+`;
+
+exports[`renders with custom percentage width 1`] = `
+.css-0,
+[data-css-0] {
+  width: 100%;
   padding: 24px 0;
   font-family: inherit;
   font-weight: 600;


### PR DESCRIPTION
This pull adds a `<SkeletonButton>` to `<Boards>`. When the button is pressed, the CreateBoardModal opens.

![image](https://user-images.githubusercontent.com/10774982/39141650-3c237324-46dd-11e8-9271-42731effb1c4.png)


So that the `<SkeletonButton>` could adjust widths along with the other grid components, an optional `width` property was added to `<SkeletonButton>`. This value just defaults to `'auto'`.

I also adjusted the padding of the `<SkeletonButton>`  on mobile.

![image](https://user-images.githubusercontent.com/10774982/39141780-9b4c6c66-46dd-11e8-8d98-762d0c82b6b4.png)

Closes #18 