### PR TITLE
Add DeleteColumnModal

### DIFF
--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -3,7 +3,10 @@ import { shape, string } from 'prop-types'
 import { gql } from 'apollo-boost'
 import { Mutation } from 'react-apollo'
 import glamorous from 'glamorous'
+import { Subscribe } from 'unstated'
 
+import ModalContainer from '../containers/ModalContainer'
+import DeleteColumnModal from './DeleteColumnModal'
 import { BOARD_QUERY } from './BoardPage'
 import { spacing, colors, radii, shadows } from '../theme'
 import ColumnForm from './ColumnForm'
@@ -91,15 +94,21 @@ class Column extends Component {
                     <Button kind="secondary" onClick={this.toggleEdit}>
                       Edit column
                     </Button>
-                    <Button
-                      kind="secondary"
-                      onClick={() =>
-                        // TODO: open a delete confirmation modal
-                        deleteColumn({ variables: { id: column.id } })
-                      }
-                    >
-                      Delete column
-                    </Button>
+                    <Subscribe to={[ModalContainer]}>
+                      {modal => (
+                        <Button
+                          kind="danger"
+                          onClick={() =>
+                            modal.openModal(DeleteColumnModal, {
+                              boardId,
+                              column,
+                            })
+                          }
+                        >
+                          Delete column
+                        </Button>
+                      )}
+                    </Subscribe>
                   </Fragment>
                 )}
                 {isEditing && (

--- a/src/components/DeleteBoardModal.js
+++ b/src/components/DeleteBoardModal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { func, shape, string } from 'prop-types'
 import { gql } from 'apollo-boost'
 import { Mutation } from 'react-apollo'
@@ -32,7 +32,7 @@ function DeleteBoardModal({ closeModal, board, history }) {
     >
       {deleteBoard => (
         <Modal isOpen onRequestClose={closeModal}>
-          <React.Fragment>
+          <Fragment>
             <h1>Delete board</h1>
             <p>
               Are you sure you want to delete <strong>{board.name}</strong>?
@@ -51,7 +51,7 @@ function DeleteBoardModal({ closeModal, board, history }) {
             >
               Delete
             </Button>
-          </React.Fragment>
+          </Fragment>
         </Modal>
       )}
     </Mutation>

--- a/src/components/DeleteColumnModal.js
+++ b/src/components/DeleteColumnModal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { func, shape, string } from 'prop-types'
 import { gql } from 'apollo-boost'
 import { Mutation } from 'react-apollo'
@@ -39,7 +39,7 @@ function DeleteColumnModal({ boardId, column, closeModal }) {
     >
       {deleteColumn => (
         <Modal isOpen onRequestClose={closeModal}>
-          <React.Fragment>
+          <Fragment>
             <h1>Delete column</h1>
             <p>
               Are you sure you want to delete <strong>{column.name}</strong>?
@@ -57,7 +57,7 @@ function DeleteColumnModal({ boardId, column, closeModal }) {
             >
               Delete
             </Button>
-          </React.Fragment>
+          </Fragment>
         </Modal>
       )}
     </Mutation>

--- a/src/components/DeleteColumnModal.js
+++ b/src/components/DeleteColumnModal.js
@@ -68,6 +68,7 @@ DeleteColumnModal.propTypes = {
   boardId: string.isRequired,
   column: shape({
     name: string.isRequired,
+    id: string.isRequired,
   }).isRequired,
   closeModal: func.isRequired,
 }

--- a/src/components/DeleteColumnModal.js
+++ b/src/components/DeleteColumnModal.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import { func, shape, string } from 'prop-types'
+import { gql } from 'apollo-boost'
+import { Mutation } from 'react-apollo'
+import Modal from 'react-modal'
+
+import Button from './Button'
+import { BOARD_QUERY } from './BoardPage'
+
+const DELETE_COLUMN_MUTATION = gql`
+  mutation DeleteColumnMutation($id: ID!) {
+    deleteColumn(id: $id) {
+      id
+    }
+  }
+`
+
+function DeleteColumnModal({ boardId, column, closeModal }) {
+  return (
+    <Mutation
+      mutation={DELETE_COLUMN_MUTATION}
+      update={(cache, { data }) => {
+        const { board } = cache.readQuery({
+          query: BOARD_QUERY,
+          variables: { id: boardId },
+        })
+        cache.writeQuery({
+          query: BOARD_QUERY,
+          data: {
+            board: {
+              ...board,
+              columns: board.columns.filter(
+                column => column.id !== data.deleteColumn.id,
+              ),
+            },
+          },
+        })
+      }}
+    >
+      {deleteColumn => (
+        <Modal isOpen onRequestClose={closeModal}>
+          <React.Fragment>
+            <h1>Delete column</h1>
+            <p>
+              Are you sure you want to delete <strong>{column.name}</strong>?
+              This action cannot be undone.
+            </p>
+            <Button kind="secondary" onClick={closeModal}>
+              Cancel
+            </Button>
+            <Button
+              kind="danger"
+              onClick={() => {
+                deleteColumn({ variables: { id: column.id } })
+                closeModal()
+              }}
+            >
+              Delete
+            </Button>
+          </React.Fragment>
+        </Modal>
+      )}
+    </Mutation>
+  )
+}
+
+DeleteColumnModal.propTypes = {
+  boardId: string.isRequired,
+  column: shape({
+    name: string.isRequired,
+  }).isRequired,
+  closeModal: func.isRequired,
+}
+
+export default DeleteColumnModal


### PR DESCRIPTION
This adds a DeleteColumnModal that will open when the 'Delete column' button is pressed.
Since columns can also be deleted by pressing 'Cancel', we have a lot of repeated code here. Any thoughts how we can abstract out some of this logic?

closes #19 