### PR TITLE
Set cascading delete on relations

### DIFF
--- a/server/database/datamodel.graphql
+++ b/server/database/datamodel.graphql
@@ -6,23 +6,23 @@ type User @model {
   name: String
   login: String! @unique
   avatarUrl: String!
-  boards: [Board!]!
+  boards: [Board!]! @relation(name: "UserToBoards", onDelete: CASCADE)
 }
 
 type Board @model {
   id: ID! @unique
   createdAt: DateTime!
   updatedAt: DateTime!
-  owner: User!
+  owner: User! @relation(name: "UserToBoards")
   name: String!
-  columns: [Column!]!
+  columns: [Column!]! @relation(name: "BoardToColumns", onDelete: CASCADE)
 }
 
 type Column @model {
   id: ID! @unique
   createdAt: DateTime!
   updatedAt: DateTime!
-  board: Board!
+  board: Board! @relation(name: "BoardToColumns")
   index: Int!
   name: String!
   query: String!

--- a/server/src/generated/prisma.graphql
+++ b/server/src/generated/prisma.graphql
@@ -149,6 +149,10 @@ input BoardSubscriptionWhereInput {
   """
   OR: [BoardSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [BoardSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -225,6 +229,10 @@ input BoardWhereInput {
   Logical OR on all given filters.
   """
   OR: [BoardWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [BoardWhereInput!]
   id: ID
   """
   All values that are not equal to given value.
@@ -487,6 +495,10 @@ input ColumnSubscriptionWhereInput {
   """
   OR: [ColumnSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [ColumnSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -547,6 +559,10 @@ input ColumnWhereInput {
   Logical OR on all given filters.
   """
   OR: [ColumnWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [ColumnWhereInput!]
   id: ID
   """
   All values that are not equal to given value.
@@ -985,6 +1001,10 @@ input UserSubscriptionWhereInput {
   """
   OR: [UserSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [UserSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -1040,6 +1060,10 @@ input UserWhereInput {
   Logical OR on all given filters.
   """
   OR: [UserWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [UserWhereInput!]
   id: ID
   """
   All values that are not equal to given value.

--- a/server/src/generated/prisma.ts
+++ b/server/src/generated/prisma.ts
@@ -141,6 +141,10 @@ input BoardSubscriptionWhereInput {
   """
   OR: [BoardSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [BoardSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -217,6 +221,10 @@ input BoardWhereInput {
   Logical OR on all given filters.
   """
   OR: [BoardWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [BoardWhereInput!]
   id: ID
   """
   All values that are not equal to given value.
@@ -479,6 +487,10 @@ input ColumnSubscriptionWhereInput {
   """
   OR: [ColumnSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [ColumnSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -539,6 +551,10 @@ input ColumnWhereInput {
   Logical OR on all given filters.
   """
   OR: [ColumnWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [ColumnWhereInput!]
   id: ID
   """
   All values that are not equal to given value.
@@ -931,6 +947,10 @@ input UserSubscriptionWhereInput {
   """
   OR: [UserSubscriptionWhereInput!]
   """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [UserSubscriptionWhereInput!]
+  """
   The subscription event gets dispatched when it's listed in mutation_in
   """
   mutation_in: [MutationType!]
@@ -986,6 +1006,10 @@ input UserWhereInput {
   Logical OR on all given filters.
   """
   OR: [UserWhereInput!]
+  """
+  Logical NOT on all given filters combined by AND.
+  """
+  NOT: [UserWhereInput!]
   id: ID
   """
   All values that are not equal to given value.
@@ -1420,6 +1444,7 @@ export interface UserCreateOneWithoutBoardsInput {
 export interface UserWhereInput {
   AND?: UserWhereInput[] | UserWhereInput
   OR?: UserWhereInput[] | UserWhereInput
+  NOT?: UserWhereInput[] | UserWhereInput
   id?: ID_Input
   id_not?: ID_Input
   id_in?: ID_Input[] | ID_Input
@@ -1541,6 +1566,7 @@ export interface ColumnUpdateWithWhereUniqueWithoutBoardInput {
 export interface BoardSubscriptionWhereInput {
   AND?: BoardSubscriptionWhereInput[] | BoardSubscriptionWhereInput
   OR?: BoardSubscriptionWhereInput[] | BoardSubscriptionWhereInput
+  NOT?: BoardSubscriptionWhereInput[] | BoardSubscriptionWhereInput
   mutation_in?: MutationType[] | MutationType
   updatedFields_contains?: String
   updatedFields_contains_every?: String[] | String
@@ -1629,6 +1655,7 @@ export interface ColumnUpdateManyWithoutBoardInput {
 export interface ColumnSubscriptionWhereInput {
   AND?: ColumnSubscriptionWhereInput[] | ColumnSubscriptionWhereInput
   OR?: ColumnSubscriptionWhereInput[] | ColumnSubscriptionWhereInput
+  NOT?: ColumnSubscriptionWhereInput[] | ColumnSubscriptionWhereInput
   mutation_in?: MutationType[] | MutationType
   updatedFields_contains?: String
   updatedFields_contains_every?: String[] | String
@@ -1646,6 +1673,7 @@ export interface UserCreateWithoutBoardsInput {
 export interface UserSubscriptionWhereInput {
   AND?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput
   OR?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput
+  NOT?: UserSubscriptionWhereInput[] | UserSubscriptionWhereInput
   mutation_in?: MutationType[] | MutationType
   updatedFields_contains?: String
   updatedFields_contains_every?: String[] | String
@@ -1667,6 +1695,7 @@ export interface ColumnWhereUniqueInput {
 export interface ColumnWhereInput {
   AND?: ColumnWhereInput[] | ColumnWhereInput
   OR?: ColumnWhereInput[] | ColumnWhereInput
+  NOT?: ColumnWhereInput[] | ColumnWhereInput
   id?: ID_Input
   id_not?: ID_Input
   id_in?: ID_Input[] | ID_Input
@@ -1793,6 +1822,7 @@ export interface UserWhereUniqueInput {
 export interface BoardWhereInput {
   AND?: BoardWhereInput[] | BoardWhereInput
   OR?: BoardWhereInput[] | BoardWhereInput
+  NOT?: BoardWhereInput[] | BoardWhereInput
   id?: ID_Input
   id_not?: ID_Input
   id_in?: ID_Input[] | ID_Input


### PR DESCRIPTION
This pull ensures that when a board is deleted, all of its columns are also deleted. When a user is deleted, all of their boards are also deleted.

Closes #20