### PR TITLE
Specify drag and drop handle

### DIFF
--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { shape, string, bool, func } from 'prop-types'
+import { shape, string, bool, func, object } from 'prop-types'
 import { gql } from 'apollo-boost'
 import { Mutation } from 'react-apollo'
 import glamorous from 'glamorous'
@@ -58,6 +58,7 @@ class Column extends Component {
     }).isRequired,
     isDragging: bool.isRequired,
     innerRef: func.isRequired,
+    dragHandleProps: object.isRequired,
   }
 
   state = {
@@ -69,7 +70,7 @@ class Column extends Component {
   toggleEdit = () => this.setState(state => ({ isEditing: !state.isEditing }))
 
   render() {
-    const { boardId, column, ...props } = this.props
+    const { boardId, column, dragHandleProps, ...props } = this.props
     const { isEditing, name, query } = this.state
     return (
       <Mutation mutation={UPDATE_COLUMN_MUTATION}>
@@ -103,6 +104,7 @@ class Column extends Component {
                       alignItems="center"
                       padding={spacing[1]}
                       paddingLeft={spacing[3]}
+                      {...dragHandleProps}
                     >
                       <strong>{name || 'Untitled Column'}</strong>
                       <Spacer />

--- a/src/components/Columns.js
+++ b/src/components/Columns.js
@@ -139,8 +139,8 @@ class Columns extends Component {
                                     column={column}
                                     isDragging={snapshot.isDragging}
                                     innerRef={provided.innerRef}
+                                    dragHandleProps={provided.dragHandleProps}
                                     {...provided.draggableProps}
-                                    {...provided.dragHandleProps}
                                   />
                                 )}
                               </Draggable>


### PR DESCRIPTION
This pull moves the moves the dragHandleProps to Column header Flex div. This means that the drag and drop handle will only be on the column header, instead of the whole column.