### PR TITLE
Board page layout

### DIFF
--- a/src/components/BoardPage.js
+++ b/src/components/BoardPage.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { Query } from 'react-apollo'
 import BoardHeader from './BoardHeader'
 import Columns from './Columns'
+import Flex from './Flex'
 import NotFoundPage from './NotFoundPage'
 
 export const BOARD_QUERY = gql`
@@ -30,10 +31,10 @@ function BoardPage({ match }) {
         if (!data.board) return <NotFoundPage />
 
         return (
-          <div>
+          <Flex flexDirection="column" height="100vh">
             <BoardHeader board={data.board} />
             <Columns boardId={data.board.id} columns={data.board.columns} />
-          </div>
+          </Flex>
         )
       }}
     </Query>

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -45,6 +45,7 @@ const ColumnContainer = system(
     display: 'flex',
     flexDirection: 'column',
     width: COLUMN_WIDTH,
+    maxHeight: '100%',
     mr: 4,
     bg: 'white',
     borderRadius: 2,
@@ -119,7 +120,13 @@ class Column extends Component {
               <ColumnContainer {...props}>
                 <Subscribe to={[ModalContainer]}>
                   {modal => (
-                    <Flex alignItems="center" p={2} pl={4} {...dragHandleProps}>
+                    <Flex
+                      alignItems="center"
+                      flex="0 0 auto"
+                      p={2}
+                      pl={4}
+                      {...dragHandleProps}
+                    >
                       <Heading is="span" fontSize={2}>
                         {name || 'Untitled Column'}
                       </Heading>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,7 @@ import system from 'system-components/emotion'
 const Header = system({
   is: 'div',
   display: 'flex',
+  flex: '0 0 auto',
   alignItems: 'center',
   height: 56,
   px: 4,

--- a/src/components/Issues.js
+++ b/src/components/Issues.js
@@ -74,7 +74,7 @@ class Issues extends Component {
     const { issues, hasNextPage, endCursor } = this.state
 
     return (
-      <div>
+      <div css={{ overflowY: 'auto' }}>
         <div>{issues.map(issue => <Issue key={issue.id} issue={issue} />)}</div>
         {hasNextPage && (
           <Button onClick={() => this.loadMore(query, endCursor)}>


### PR DESCRIPTION
This pull prevents columns from going below the fold. Instead, the issues inside each column now scroll independently.

Closes #43